### PR TITLE
WiFi with no password was causing issues with netplan generate

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -368,6 +368,8 @@ $('#generateconfig').click(function()
 
     if(wifi_passphrase != "" || wifi_hidden_ssid) {
       v2Str += "          password: \"" + wifi_passphrase + "\"\r\n";
+    } else {
+      v2Str += "          {}\r\n"
     }
 
     if(wifi_dhcp == true) {


### PR DESCRIPTION
How to reproduce:

1. Generate a config for open wifi and install it on the screenly device.
2. From the console run `sudo netplan generate`

You will get
```
pi@localhost:/etc/netplan$ sudo netplan generate
Error in network definition //etc/netplan/00-snapd-config.yaml line 15 column 25: expected mapping
```